### PR TITLE
Make fsevents an optional dependency for compatibilty with linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,10 @@
     "cypress": "^3.8.3",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
-    "fsevents": "^2.1.2",
     "node-sass": "^4.13.1",
     "react-test-renderer": "^16.12.0"
+  },
+  "optionalDependencies": {
+        "fsevents": "^2.1.2"
   }
 }


### PR DESCRIPTION
This fixes my issue with npm install giving err on fsevents